### PR TITLE
Use older macOS version with Intel CPU because the OOMMF M1 conda pac…

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.10"]
     defaults:
       run:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         auto-update-conda: true


### PR DESCRIPTION
…kage is still missing

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories