### PR TITLE
Support for numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy~=1.19",
+    "numpy>=1.19",
     "pytest>=6.2",
     "tqdm"
 ]

--- a/ubermagutil/tools.py
+++ b/ubermagutil/tools.py
@@ -59,11 +59,9 @@ def hysteresis_values(vmin, vmax, step):
         msg = "Value range cannot be divided into integer number of steps."
         raise ValueError(msg)
 
-    return list(
-        np.concatenate(
-            [np.arange(vmax, vmin, -step), np.arange(vmin, vmax + rtol * step, step)]
-        )
-    )
+    return np.concatenate(
+        [np.arange(vmax, vmin, -step), np.arange(vmin, vmax + rtol * step, step)]
+    ).tolist()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Using `.tolist()` converts the data types back to python builtins and avoids the problem with the repr string.